### PR TITLE
convert list to tuple

### DIFF
--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -211,7 +211,7 @@ class Matcher():
             pairs = pairs[valid]
 
         pairs = np.unique(pairs, axis=0)
-        return {None: pairs.tolist()}
+        return {None: list(map(tuple, pairs))}
 
     def _filter_diffby(self, idx: int, diffby: ColumnList, valid: Set[int]):
         '''


### PR DESCRIPTION
Negative pairs with empty `sameby` gets `list`s instead of `tuple`s. Forcing to be `tuple`s before adding them to the `set`