### PR TITLE
add option to randomly sample negative pairs

### DIFF
--- a/src/copairs/map/average_precision.py
+++ b/src/copairs/map/average_precision.py
@@ -27,7 +27,7 @@ def build_rank_lists(pos_pairs, neg_pairs, pos_sims, neg_sims):
     return paired_ix, rel_k_list, counts
 
 def average_precision(
-    meta, feats, pos_sameby, pos_diffby, neg_sameby, neg_diffby, batch_size=20000, sample_neg: float = 1
+    meta, feats, pos_sameby, pos_diffby, neg_sameby, neg_diffby, batch_size=20000, sample_neg: bool = False, sample_factor: float = 10
 ) -> pd.DataFrame:
     columns = flatten_str_list(pos_sameby, pos_diffby, neg_sameby, neg_diffby)
     validate_pipeline_input(meta, feats, columns)
@@ -60,18 +60,11 @@ def average_precision(
     )
 
     # if sample_neg not equal to 1, randomly sample negative pairs
-    if (sample_neg > 1) & (sample_neg < neg_pairs.shape[0]):
-        sampled_rows = np.random.choice(neg_pairs.shape[0], size=sample_neg, replace=False)
-        neg_pairs = neg_pairs[sampled_rows]
-    elif (sample_neg > 1) & (sample_neg >= neg_pairs.shape[0]):
-        raise UnpairedException("'sample_neg' must be less than the number of negative pairs. There are " + str(neg_pairs.shape[0]) + " negative pairs in this analysis.")
-    elif (sample_neg > 0) & (sample_neg < 1):
-        sample_size = round(sample_neg*neg_pairs.shape[0])
-        sampled_rows = np.random.choice(neg_pairs.shape[0], size=sample_size, replace=False)
-        neg_pairs = neg_pairs[sampled_rows]
-    elif sample_neg <= 0:
-        raise UnpairedException("'sample_neg' must be greater than 0.")
-
+    if sample_neg:
+        sample_size = pos_pairs.shape[0]*sample_factor
+        if sample_size < neg_pairs.shape[0]:
+            sampled_rows = np.random.choice(neg_pairs.shape[0], size=sample_size, replace=False)
+            neg_pairs = neg_pairs[sampled_rows]
 
     logger.info("Computing positive similarities...")
     pos_sims = compute.pairwise_cosine(feats, pos_pairs, batch_size)


### PR DESCRIPTION
Add an optional parameter to the "average_precision" function called "sample_neg" that enables random sampling of the negative pairs prior to pairwise cosine distance calculation. 

If "sample_neg" is between 0 and 1, sampling is done by percentage (ie. sample_neg = 0.2, then 20% of neg_pairs are sampled).

If "sample_neg" is greater than 1, sampling is done by size (ie. sample_neg = 10 000, then 10 000 neg_pairs are sampled). 

The default value for "sample_neg" is 1 - in this case, no sampling is performed. 