### PR TITLE
Optimise matching process using duckdb

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739357830,
+        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_master": {
+      "locked": {
+        "lastModified": 1739550317,
+        "narHash": "sha256-Tdrwxe81xIMTAzX2lQaoU+Sz3JDTHtUEzLFYBv84IB0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5866d80b157e31becb14f9084ba560b818f7e989",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs_master": "nixpkgs_master",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs_master.url = "github:NixOS/nixpkgs/master";
+    systems.url = "github:nix-systems/default";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.systems.follows = "systems";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }@inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+          config.cudaSupport = true;
+        };
+
+        mpkgs = import inputs.nixpkgs_master {
+          inherit system;
+          config.allowUnfree = true;
+          config.cudaSupport = true;
+        };
+
+        libList =
+          [
+            # Add needed packages here
+            pkgs.stdenv.cc.cc
+            pkgs.libGL
+            pkgs.glib
+            pkgs.zlib
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux (
+            with pkgs;
+            [
+            ]
+          );
+      in
+      with pkgs;
+      {
+        devShells = {
+          default =
+            let
+              python_with_pkgs = pkgs.python311.withPackages (pp: [
+                # Add python pkgs here that you need from nix repos
+              ]);
+            in
+            mkShell {
+              NIX_LD = runCommand "ld.so" { } ''
+                ln -s "$(cat '${pkgs.stdenv.cc}/nix-support/dynamic-linker')" $out
+              '';
+              NIX_LD_LIBRARY_PATH = lib.makeLibraryPath libList;
+              packages = [
+                python_with_pkgs
+                python311Packages.venvShellHook
+                mpkgs.uv
+
+              ] ++ libList;
+              venvDir = "./.venv";
+              postVenvCreation = ''
+                unset SOURCE_DATE_EPOCH
+              '';
+              postShellHook = ''
+                unset SOURCE_DATE_EPOCH
+              '';
+              shellHook = ''
+                export LD_LIBRARY_PATH=$NIX_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+                export PYTHON_KEYRING_BACKEND=keyring.backends.fail.Keyring
+                runHook venvShellHook
+                uv pip install -e .
+                export PYTHONPATH=${python_with_pkgs}/${python_with_pkgs.sitePackages}:$PYTHONPATH
+              '';
+            };
+        };
+      }
+    );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,22 @@ license = {file = "LICENSE.txt"}
 keywords = ["pairwise", "replication"]
 authors = [
   { name = "John Arevalo", email = "johnarevalo@gmail.com" },
-  { name = "Alexandr Kalinin", email = "akalinin@broadinstitute.org" }
+  { name = "Alexandr Kalinin", email = "akalinin@broadinstitute.org" },
+  { name = "Alan F. Munoz", email = "amunozgo@broadinstitute.org" }
 ]
 dependencies = [
   "pandas",
   "tqdm",
-  "statsmodels"
+  "statsmodels",
+  "duckdb>=1.2.0",
 ]
 
 [project.optional-dependencies]
-dev = ["ruff"]
+dev = [
+    "ipdb>=0.13.13",
+    "jupyter>=1.1.1",
+    "ruff",
+]
 plot = ["plotly"]
 test = ["scikit-learn", "pytest"]
 demo = ["notebook", "matplotlib"]
@@ -39,3 +45,13 @@ select = ["D"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[dependency-groups]
+dev = [
+    "jupyter>=1.1.1",
+    "trepan3k>=1.3.1",
+]
+test = [
+    "pytest>=8.3.4",
+    "scikit-learn>=1.3.2",
+]

--- a/src/copairs/map/average_precision.py
+++ b/src/copairs/map/average_precision.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from copairs import compute
-from copairs.matching import Matcher, UnpairedException
+from copairs.matching import UnpairedException, find_pairs
 
 from .filter import evaluate_and_filter, flatten_str_list, validate_pipeline_input
 
@@ -178,37 +178,19 @@ def average_precision(
     # Reset metadata index for consistent indexing
     meta = meta.reset_index(drop=True).copy()
 
-    # Initialize the Matcher object to find pairs based on metadata rules
     logger.info("Indexing metadata...")
-    matcher = Matcher(meta, columns, seed=0)
 
     # Identify positive pairs based on `pos_sameby` and `pos_diffby`
     logger.info("Finding positive pairs...")
-    pos_pairs = matcher.get_all_pairs(sameby=pos_sameby, diffby=pos_diffby)
-    pos_total = sum(len(p) for p in pos_pairs.values())
-    if pos_total == 0:
+    pos_pairs = find_pairs(meta, sameby=pos_sameby, diffby=pos_diffby)
+    if len(pos_pairs) == 0:
         raise UnpairedException("Unable to find positive pairs.")
-
-    # Convert positive pairs to a NumPy array for efficient computation
-    pos_pairs = np.fromiter(
-        itertools.chain.from_iterable(pos_pairs.values()),
-        dtype=np.dtype((np.uint32, 2)),
-        count=pos_total,
-    )
 
     # Identify negative pairs based on `neg_sameby` and `neg_diffby`
     logger.info("Finding negative pairs...")
-    neg_pairs = matcher.get_all_pairs(sameby=neg_sameby, diffby=neg_diffby)
-    neg_total = sum(len(p) for p in neg_pairs.values())
-    if neg_total == 0:
+    neg_pairs = find_pairs(meta, sameby=neg_sameby, diffby=neg_diffby)
+    if len(neg_pairs) == 0:
         raise UnpairedException("Unable to find negative pairs.")
-
-    # Convert negative pairs to a NumPy array for efficient computation
-    neg_pairs = np.fromiter(
-        itertools.chain.from_iterable(neg_pairs.values()),
-        dtype=np.dtype((np.uint32, 2)),
-        count=neg_total,
-    )
 
     # Compute similarities for positive pairs
     logger.info("Computing positive similarities...")

--- a/src/copairs/map/map.py
+++ b/src/copairs/map/map.py
@@ -87,6 +87,7 @@ def mean_average_precision(
 
     # Compute p-values for each group using the null distributions
     params = map_scores[["mean_average_precision", "indices"]]
+
     map_scores["p_value"] = thread_map(
         get_p_value, params.values, leave=False, max_workers=max_workers
     )

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from copairs import Matcher
+from copairs.matching import find_pairs
 from tests.helpers import create_dframe, simulate_plates, simulate_random_dframe
 
 SEED = 0
@@ -14,9 +14,10 @@ SEED = 0
 
 def run_stress_sample_null(dframe, num_pairs):
     """Assert every generated null pair does not match any column."""
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
-    for _ in range(num_pairs):
-        id1, id2 = matcher.sample_null_pair(dframe.columns)
+    null_pair = find_pairs(dframe, dframe.columns, [], rev=True)
+    randints = np.random.randint(len(null_pair), size=num_pairs)
+    for i in randints:
+        id1, id2 = null_pair[i]
         row1 = dframe.loc[id1]
         row2 = dframe.loc[id2]
         assert (row1 != row2).all()
@@ -61,11 +62,12 @@ def get_naive_pairs(dframe: pd.DataFrame, sameby, diffby):
     return pairs
 
 
-def check_naive(dframe, matcher: Matcher, sameby, diffby):
+def check_naive(dframe, sameby, diffby):
     """Check Matcher and naive generate same pairs."""
     gt_pairs = get_naive_pairs(dframe, sameby, diffby)
-    vals = matcher.get_all_pairs(sameby, diffby)
-    vals = sum(vals.values(), [])
+    # vals = matcher.get_all_pairs(sameby, diffby)
+    vals = find_pairs(dframe, sameby, diffby)
+    # vals = sum(vals.values(), [])
     vals = pd.DataFrame(vals, columns=["index_x", "index_y"])
     vals = vals.sort_values(["index_x", "index_y"]).reset_index(drop=True)
     vals = set(vals.apply(frozenset, axis=1))
@@ -76,8 +78,7 @@ def check_naive(dframe, matcher: Matcher, sameby, diffby):
 def check_simulated_data(length, vocab_size, sameby, diffby, rng):
     """Test sample of valid pairs from a simulated dataset."""
     dframe = simulate_random_dframe(length, vocab_size, sameby, diffby, rng)
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
-    check_naive(dframe, matcher, sameby, diffby)
+    check_naive(dframe, sameby, diffby)
 
 
 def test_stress_simulated_data():
@@ -101,51 +102,44 @@ def test_stress_simulated_data():
 def test_empty_sameby():
     """Test query without sameby."""
     dframe = create_dframe(3, 10)
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
-    check_naive(dframe, matcher, sameby=[], diffby=["w", "c"])
-    check_naive(dframe, matcher, sameby=[], diffby=["w"])
+    check_naive(dframe, sameby=[], diffby=["w", "c"])
+    check_naive(dframe, sameby=[], diffby=["w"])
 
 
 def test_empty_diffby():
     """Test query without diffby."""
     dframe = create_dframe(3, 10)
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
-    matcher.get_all_pairs(["c"], [])
-    check_naive(dframe, matcher, sameby=["c"], diffby=[])
-    check_naive(dframe, matcher, sameby=["w", "c"], diffby=[])
+    check_naive(dframe, sameby=["c"], diffby=[])
+    check_naive(dframe, sameby=["w", "c"], diffby=[])
 
 
 def test_raise_distjoint():
     """Test check for disjoint sameby and diffby."""
     dframe = create_dframe(3, 10)
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
     with pytest.raises(ValueError, match="must be disjoint lists"):
-        matcher.get_all_pairs("c", ["w", "c"])
+        find_pairs(dframe, "c", ["w", "c"])
 
 
 def test_raise_no_params():
     """Test check for at least one of sameby and diffby."""
     dframe = create_dframe(3, 10)
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
     with pytest.raises(ValueError, match="at least one should be provided"):
-        matcher.get_all_pairs([], [])
+        find_pairs(dframe, [], [])
 
 
-def assert_sameby_diffby(dframe: pd.DataFrame, pairs_dict: dict, sameby, diffby):
+def assert_sameby_diffby(dframe: pd.DataFrame, pairs: dict, sameby, diffby):
     """Assert the pairs are valid."""
-    for _, pairs in pairs_dict.items():
-        for id1, id2 in pairs:
-            for col in sameby:
-                assert dframe.loc[id1, col] == dframe.loc[id2, col]
-            for col in diffby:
-                assert dframe.loc[id1, col] != dframe.loc[id2, col]
+    for id1, id2 in pairs:
+        for col in sameby:
+            assert dframe.loc[id1, col] == dframe.loc[id2, col]
+        for col in diffby:
+            assert dframe.loc[id1, col] != dframe.loc[id2, col]
 
 
 def test_simulate_plates_mult_sameby_large():
     """Test matcher successfully complete analysis of a large dataset."""
     dframe = simulate_plates(n_compounds=15000, n_replicates=20, plate_size=384)
-    matcher = Matcher(dframe, dframe.columns, seed=SEED)
     sameby = ["c", "w"]
     diffby = ["p"]
-    pairs_dict = matcher.get_all_pairs(sameby, diffby)
+    pairs_dict = find_pairs(dframe, sameby, diffby)
     assert_sameby_diffby(dframe, pairs_dict, sameby, diffby)

--- a/tests/test_matching_multilabel.py
+++ b/tests/test_matching_multilabel.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from copairs.matching import MatcherMultilabel
+from copairs.matching import find_pairs_multilabel
 from tests.helpers import simulate_random_plates
 
 SEED = 42
@@ -47,11 +47,10 @@ def get_naive_pairs(dframe: pd.DataFrame, sameby, diffby, multilabel_col: str):
     return pairs
 
 
-def check_naive(dframe, matcher: MatcherMultilabel, sameby, diffby, multilabel_col):
-    """Check Matcher and naive generate same pairs."""
+def check_naive(dframe, sameby, diffby, multilabel_col):
+    """Check find_pairs_multilabel and naive generate same pairs."""
     gt_pairs = get_naive_pairs(dframe, sameby, diffby, multilabel_col)
-    vals = matcher.get_all_pairs(sameby, diffby)
-    vals = sum(vals.values(), [])
+    vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
     vals = pd.DataFrame(vals, columns=["index_x", "index_y"])
     vals = vals.sort_values(["index_x", "index_y"]).reset_index(drop=True)
     vals = set(vals.apply(frozenset, axis=1))
@@ -68,8 +67,7 @@ def test_sameby():
         n_compounds=4, n_replicates=5, plate_size=5, sameby=sameby, diffby=diffby
     )
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
-    matcher = MatcherMultilabel(dframe, dframe.columns, multilabel_col, seed=SEED)
-    check_naive(dframe, matcher, sameby, diffby, multilabel_col)
+    check_naive(dframe, sameby, diffby, multilabel_col)
 
 
 def test_diffby():
@@ -81,9 +79,8 @@ def test_diffby():
         n_compounds=4, n_replicates=5, plate_size=5, sameby=sameby, diffby=diffby
     )
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
-    matcher = MatcherMultilabel(dframe, dframe.columns, multilabel_col, seed=SEED)
 
-    check_naive(dframe, matcher, sameby, diffby, multilabel_col)
+    check_naive(dframe, sameby, diffby, multilabel_col)
 
 
 def test_only_diffby():
@@ -95,8 +92,7 @@ def test_only_diffby():
         n_compounds=4, n_replicates=5, plate_size=5, sameby=sameby, diffby=diffby
     )
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
-    matcher = MatcherMultilabel(dframe, dframe.columns, multilabel_col, seed=SEED)
-    check_naive(dframe, matcher, sameby, diffby, multilabel_col)
+    check_naive(dframe, sameby, diffby, multilabel_col)
 
 
 def test_only_diffby_many_cols():
@@ -108,8 +104,7 @@ def test_only_diffby_many_cols():
         n_compounds=4, n_replicates=5, plate_size=5, sameby=sameby, diffby=diffby
     )
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
-    matcher = MatcherMultilabel(dframe, dframe.columns, multilabel_col, seed=SEED)
-    check_naive(dframe, matcher, sameby, diffby, multilabel_col)
+    check_naive(dframe, sameby, diffby, multilabel_col)
 
 
 def test_only_sameby_many_cols():
@@ -121,5 +116,4 @@ def test_only_sameby_many_cols():
         n_compounds=4, n_replicates=5, plate_size=5, sameby=sameby, diffby=diffby
     )
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
-    matcher = MatcherMultilabel(dframe, dframe.columns, multilabel_col, seed=SEED)
-    check_naive(dframe, matcher, sameby, diffby, multilabel_col)
+    check_naive(dframe, sameby, diffby, multilabel_col)


### PR DESCRIPTION
I have the strong intuition that duckdb can speed up matching by quite a bit (and also the code would be considerably simpler). So I decided to test it out.

EDIT: Current benchmarking code:
```python
from timeit import Timer

setup = """
import pandas as pd

from copairs.matching import Matcher, find_pairs

def simulate_plates(n_compounds, n_replicates, plate_size):
    total = n_compounds * n_replicates

    compounds = []
    plates = []
    wells = []
    for i in range(total):
        compound_id = i % n_compounds
        well_id = i % plate_size
        plate_id = i // plate_size
        compounds.append(f"c{{compound_id}}")
        plates.append(f"p{{plate_id}}")
        wells.append(f"w{{well_id}}")

    dframe = pd.DataFrame({{"c": compounds, "p": plates, "w": wells}})
    return dframe

sameby = ["c", "w"]
diffby = []
SEED = 42
n_replicates = 20
plate_size = 384

dframe = simulate_plates({}, n_replicates, plate_size)
# Load matcher
matcher = Matcher(dframe, dframe.columns, seed=SEED)

"""

n_times = 3
n_repeats = 5
for n_compounds in (10**i for i in range(3, 6)):
    for fn in (
        "find_pairs(dframe,sameby,diffby)",
        "matcher.get_all_pairs(sameby,diffby)",
    ):
        times = Timer(fn, setup=setup.format(n_compounds)).repeat(n_times, n_repeats)
        avg = sum(times) / n_repeats
        print(f"{fn.split('(')[0]},{n_compounds=} has an avg time of {avg:0.3f} secs.")
```

```
matcher.get_all_pairs,n_compounds=1000 has an avg time of 1.760 secs.
matcher.get_all_pairs,n_compounds=10000 has an avg time of 17.325 secs.
matcher.get_all_pairs,n_compounds=100000 has an avg time of 177.668 secs.
find_pairs,n_compounds=1000 has an avg time of 0.061 secs.
find_pairs,n_compounds=10000 has an avg time of 0.148 secs.
find_pairs,n_compounds=100000 has an avg time of 0.561 secs.
```