### PR TITLE
v0.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,5 @@ cython_debug/
 #.idea/
 
 examples/data/
+examples/cache/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ We provide examples demonstrating how to use copairs for:
 ## Citation
 If you find this work useful for your research, please cite our [pre-print](https://doi.org/10.1101/2024.04.01.587631):
 
-Kalinin, A.A., Arevalo, J., Vulliard, L., Serrano, E., Tsang, H., Bornholdt, M., Rajwa, B., Carpenter, A.E., Way, G.P. and Singh, S., 2024. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, pp.2024-04. doi:10.1101/2024.04.01.587631
+Kalinin, A.A., Arevalo, J., Vulliard, L., Serrano, E., Tsang, H., Bornholdt, M., Muñoz, A.F., Sivagurunathan, S., Rajwa, B., Carpenter, A.E., Way, G.P. and Singh, S., 2024. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, pp.2024-04. doi:10.1101/2024.04.01.587631
 
 BibTeX:
 ```
 @article{kalinin2024versatile,
   title={A versatile information retrieval framework for evaluating profile strength and similarity},
-  author={Kalinin, Alexandr A and Arevalo, John and Vulliard, Loan and Serrano, Erik and Tsang, Hillary and Bornholdt, Michael and Rajwa, Bartek and Carpenter, Anne E and Way, Gregory P and Singh, Shantanu},
+  author={Kalinin, Alexandr A and Arevalo, John and Vulliard, Loan and Serrano, Erik and Tsang, Hillary and Bornholdt, Michael and Muñoz, Alán F and Sivagurunathan, Suganya and Rajwa, Bartek and Carpenter, Anne E and Way, Gregory P and Singh, Shantanu},
   journal={bioRxiv},
   pages={2024--04},
   year={2024},

--- a/examples/null_size.ipynb
+++ b/examples/null_size.ipynb
@@ -185,7 +185,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9738b6f4faa64847aac316120975c9fd",
+       "model_id": "98a5410c76d04b30a59c1e96909fa675",
        "version_major": 2,
        "version_minor": 0
       },
@@ -199,7 +199,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3a5ff0b3fb384c4f95baa77a66b504d7",
+       "model_id": "a5882a4e63ba4a2da14f8c25e5e2c451",
        "version_major": 2,
        "version_minor": 0
       },
@@ -213,7 +213,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1412262fdfca4de5a0ac2968e37defc1",
+       "model_id": "3f7dea536b344dc4a0cf07e4e2f94436",
        "version_major": 2,
        "version_minor": 0
       },
@@ -227,7 +227,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2f3bce275fab434ba1e045908ac56188",
+       "model_id": "d8108b62de1b4127967c1184f4e14ec5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -241,7 +241,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "31504e9ab9334054a5c1fa9244b00461",
+       "model_id": "71c8c110a0694b5a9c1925011d64bc29",
        "version_major": 2,
        "version_minor": 0
       },
@@ -255,7 +255,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df3ee4295bf14a0fbbd3edc9b9bbce43",
+       "model_id": "e6d5a7adab3643dcb1638b3bc617f354",
        "version_major": 2,
        "version_minor": 0
       },
@@ -269,7 +269,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "71e241775fd74abfa4e8403d365f8136",
+       "model_id": "de529c15360f45948e04127c88135f16",
        "version_major": 2,
        "version_minor": 0
       },
@@ -283,7 +283,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bc2e1817be6b4207af2458943e547500",
+       "model_id": "370a8fd49b874cc0aa4599416b087f7f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -297,7 +297,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e66adb85c1f74eaf87efae66dbbd644a",
+       "model_id": "5d0f64f1871746a4be91ca50ee8da395",
        "version_major": 2,
        "version_minor": 0
       },
@@ -311,7 +311,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8b390b25b8964592bf479b42a6320d06",
+       "model_id": "f1c498718ebf467fafa9f1a5860156fb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -325,7 +325,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8dace7243c3841cc9898fe6d304ed3ed",
+       "model_id": "2f565faa215142dd8c0d4d477eba412a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -339,7 +339,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44c48e472c6f4d5eaf3d558a8acb4519",
+       "model_id": "bfbde159bfd64bd18d62358f694db31b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -353,7 +353,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aba7957fbbf74fd78474030d6d7cd63a",
+       "model_id": "3f9a18859a1243ea9f291e81574583ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -367,7 +367,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1289bf5d7e61407e87169aba69b4bb54",
+       "model_id": "28e949a9495e4c9db59eba1bf5a488c6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -381,7 +381,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7534620ff82e4520995023f3830514f8",
+       "model_id": "b78cd24410064bdea1e9104eed78a372",
        "version_major": 2,
        "version_minor": 0
       },
@@ -395,7 +395,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8afdd30c664742769161be671d05902f",
+       "model_id": "9ab9e9d8efb64b68b64266f13dbc516d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -409,7 +409,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4292e6701ae845e2b77eea11bbdb25b5",
+       "model_id": "bc2c40c409274b378395f23bcd8aed4d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -423,7 +423,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "822431e328954a908c068da8b2bf124d",
+       "model_id": "15c6eaf126374babb2c757c93b6dcfb9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -437,7 +437,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "86c4b77801b548a2a6ee90abea3e8b0e",
+       "model_id": "769ed6f0be494e5696b15b4334e8edf8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -451,7 +451,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99c2fb7c7ab04103bcd8938f96aa5111",
+       "model_id": "1a15d7bb96f84429bb513f1458de3e93",
        "version_major": 2,
        "version_minor": 0
       },
@@ -465,7 +465,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dfc7b6b9ba654496be0bcefe5f717f59",
+       "model_id": "6998d02b1fc546c1808232bb398b3b1a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -479,7 +479,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2f45921939d4742a0d5254e404a015b",
+       "model_id": "3b3250fa2e2d4688a6834105e57226c0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -493,7 +493,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "14627090dac345a695601984a5ec128a",
+       "model_id": "2a92717d58b6495186a975d5ddf858c1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -507,7 +507,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e7980c5c222436d895c64f85104de83",
+       "model_id": "507d3b9a1f89420082741923b12f258f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -570,16 +570,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because the full null size $d_{null}=118755$, smaller sample sizes ($<5,000$) lead to poor estimation of significance for these data, while very large values ($>100,000$) cover the whole null and do not affect perturbation ranking results.\n",
+    "Because the full null size $d_{null}=118755$, smaller sample sizes ($<=1,000$) lead to poor estimation of significance for these data, while very large values ($>100,000$) cover the whole null and do not affect perturbation ranking results.\n",
     "\n",
-    "## Practical consideration for choosing null size\n",
+    "## Practical consideration for choosing the null size\n",
     "\n",
     "In practice, drawing a large number of samples is not always feasible, because compute time for each AP calculation grows with the higher number of perturbations of the dataset, the number of metadata constraints for profile grouping, sizes of perturbation groups (the number of perturbation replicates) and control groups (the number of control replicates), and profile dimensionality (the number of features in a profile).\n",
     "\n",
-    "Finding a `null_size` that works for a particular dataset is balancing between test resolution (for example, being able to tell apart vary small p-values) and compute. We provided `null_size` values for each real-world dataset in Supplemental Materials to our paper—please refer to:\n",
+    "Finding a `null_size` that works for a particular dataset means balancing between test resolution (for example, being able to tell apart vary small p-values) and compute. We provided `null_size` values for each real-world dataset in Supplemental Materials to our paper—please refer to:\n",
     "\n",
     "> Kalinin, A. A. et al. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, 2024-04, (2024)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/phenotypic_activity.ipynb
+++ b/examples/phenotypic_activity.ipynb
@@ -710,7 +710,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b54ab7add0784d17a2e10a209b760224",
+       "model_id": "78e5ce7133dd4bd5872ff223d027754c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -724,7 +724,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2227ac5c0594e439045aa76ad8ae250",
+       "model_id": "bc3329b5e2e9402896b0b3972165708f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -734,14 +734,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/akalinin/Projects/copairs/src/copairs/compute.py:401: RuntimeWarning: invalid value encountered in divide\n",
-      "  ap_scores = np.add.reduceat(pr_k * rel_k_list, cutoffs) / num_pos\n"
-     ]
     },
     {
      "data": {
@@ -1139,7 +1131,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c49761d9b5da459e83dda4d34953ca81",
+       "model_id": "3cd6a4411a884b57b85d26bcaba4edf1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1153,7 +1145,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7022b93aae7d4ca1bc4e8e9316f9c321",
+       "model_id": "094ecf400fff401ba3c45bd88132c3d5",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/phenotypic_activity.ipynb
+++ b/examples/phenotypic_activity.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -560,7 +560,7 @@
        "[384 rows x 507 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -590,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -617,7 +617,7 @@
        "       'BCL2|BCL2L1|BCL2L2'], dtype=object)"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -644,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,13 +704,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3cfeabe4061942f499ad5045f1262f51",
+       "model_id": "b54ab7add0784d17a2e10a209b760224",
        "version_major": 2,
        "version_minor": 0
       },
@@ -724,7 +724,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2c3953577f684964825b1d337b3a06bd",
+       "model_id": "a2227ac5c0594e439045aa76ad8ae250",
        "version_major": 2,
        "version_minor": 0
       },
@@ -739,7 +739,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/akalinin/Projects/copairs/src/copairs/compute.py:150: RuntimeWarning: invalid value encountered in divide\n",
+      "/Users/akalinin/Projects/copairs/src/copairs/compute.py:401: RuntimeWarning: invalid value encountered in divide\n",
       "  ap_scores = np.add.reduceat(pr_k * rel_k_list, cutoffs) / num_pos\n"
      ]
     },
@@ -1103,7 +1103,7 @@
        "[360 rows x 18 columns]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1133,13 +1133,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c684ee9c2094831a91b21b14dcbb2b0",
+       "model_id": "c49761d9b5da459e83dda4d34953ca81",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1153,7 +1153,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "45ecff1fd6544ec78fc8b7ec5203e842",
+       "model_id": "7022b93aae7d4ca1bc4e8e9316f9c321",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1188,6 +1188,7 @@
        "      <th>Metadata_broad_sample</th>\n",
        "      <th>Metadata_reference_index</th>\n",
        "      <th>mean_average_precision</th>\n",
+       "      <th>indices</th>\n",
        "      <th>p_value</th>\n",
        "      <th>corrected_p_value</th>\n",
        "      <th>below_p</th>\n",
@@ -1201,6 +1202,7 @@
        "      <td>BRD-A69275535-001-01-5</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.575629</td>\n",
+       "      <td>[96, 97, 98, 99, 100, 101]</td>\n",
        "      <td>1.725598e-02</td>\n",
        "      <td>0.023276</td>\n",
        "      <td>True</td>\n",
@@ -1212,6 +1214,7 @@
        "      <td>BRD-A69636825-003-04-7</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.693806</td>\n",
+       "      <td>[114, 115, 116, 117, 118, 119]</td>\n",
        "      <td>3.477997e-03</td>\n",
        "      <td>0.006507</td>\n",
        "      <td>True</td>\n",
@@ -1223,6 +1226,7 @@
        "      <td>BRD-A69815203-001-07-6</td>\n",
        "      <td>-1</td>\n",
        "      <td>1.000000</td>\n",
+       "      <td>[288, 289, 290, 291, 292, 293]</td>\n",
        "      <td>9.999990e-07</td>\n",
        "      <td>0.000008</td>\n",
        "      <td>True</td>\n",
@@ -1234,6 +1238,7 @@
        "      <td>BRD-A70858459-001-01-7</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.777173</td>\n",
+       "      <td>[156, 157, 158, 159, 160, 161]</td>\n",
        "      <td>8.279992e-04</td>\n",
        "      <td>0.001921</td>\n",
        "      <td>True</td>\n",
@@ -1245,6 +1250,7 @@
        "      <td>BRD-A72309220-001-04-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.716927</td>\n",
+       "      <td>[192, 193, 194, 195, 196, 197]</td>\n",
        "      <td>2.323998e-03</td>\n",
        "      <td>0.004493</td>\n",
        "      <td>True</td>\n",
@@ -1256,6 +1262,7 @@
        "      <td>BRD-A72390365-001-15-2</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.934444</td>\n",
+       "      <td>[210, 211, 212, 213, 214, 215]</td>\n",
        "      <td>2.799997e-05</td>\n",
        "      <td>0.000108</td>\n",
        "      <td>True</td>\n",
@@ -1267,6 +1274,7 @@
        "      <td>BRD-A73368467-003-17-6</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.926032</td>\n",
+       "      <td>[246, 247, 248, 249, 250, 251]</td>\n",
        "      <td>3.699996e-05</td>\n",
        "      <td>0.000134</td>\n",
        "      <td>True</td>\n",
@@ -1278,6 +1286,7 @@
        "      <td>BRD-A74980173-001-11-9</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.765931</td>\n",
+       "      <td>[18, 19, 20, 21, 22, 23]</td>\n",
        "      <td>1.017999e-03</td>\n",
        "      <td>0.002187</td>\n",
        "      <td>True</td>\n",
@@ -1289,6 +1298,7 @@
        "      <td>BRD-A81233518-004-16-1</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.621183</td>\n",
+       "      <td>[306, 307, 308, 309, 310, 311]</td>\n",
        "      <td>9.594990e-03</td>\n",
        "      <td>0.014269</td>\n",
        "      <td>True</td>\n",
@@ -1300,6 +1310,7 @@
        "      <td>BRD-A82035391-001-02-7</td>\n",
        "      <td>-1</td>\n",
        "      <td>0.318066</td>\n",
+       "      <td>[342, 343, 344, 345, 346, 347]</td>\n",
        "      <td>2.536767e-01</td>\n",
        "      <td>0.258127</td>\n",
        "      <td>False</td>\n",
@@ -1323,32 +1334,32 @@
        "8  BRD-A81233518-004-16-1                        -1                0.621183   \n",
        "9  BRD-A82035391-001-02-7                        -1                0.318066   \n",
        "\n",
-       "        p_value  corrected_p_value  below_p  below_corrected_p  \\\n",
-       "0  1.725598e-02           0.023276     True               True   \n",
-       "1  3.477997e-03           0.006507     True               True   \n",
-       "2  9.999990e-07           0.000008     True               True   \n",
-       "3  8.279992e-04           0.001921     True               True   \n",
-       "4  2.323998e-03           0.004493     True               True   \n",
-       "5  2.799997e-05           0.000108     True               True   \n",
-       "6  3.699996e-05           0.000134     True               True   \n",
-       "7  1.017999e-03           0.002187     True               True   \n",
-       "8  9.594990e-03           0.014269     True               True   \n",
-       "9  2.536767e-01           0.258127    False              False   \n",
+       "                          indices       p_value  corrected_p_value  below_p  \\\n",
+       "0      [96, 97, 98, 99, 100, 101]  1.725598e-02           0.023276     True   \n",
+       "1  [114, 115, 116, 117, 118, 119]  3.477997e-03           0.006507     True   \n",
+       "2  [288, 289, 290, 291, 292, 293]  9.999990e-07           0.000008     True   \n",
+       "3  [156, 157, 158, 159, 160, 161]  8.279992e-04           0.001921     True   \n",
+       "4  [192, 193, 194, 195, 196, 197]  2.323998e-03           0.004493     True   \n",
+       "5  [210, 211, 212, 213, 214, 215]  2.799997e-05           0.000108     True   \n",
+       "6  [246, 247, 248, 249, 250, 251]  3.699996e-05           0.000134     True   \n",
+       "7        [18, 19, 20, 21, 22, 23]  1.017999e-03           0.002187     True   \n",
+       "8  [306, 307, 308, 309, 310, 311]  9.594990e-03           0.014269     True   \n",
+       "9  [342, 343, 344, 345, 346, 347]  2.536767e-01           0.258127    False   \n",
        "\n",
-       "   -log10(p-value)  \n",
-       "0         1.633101  \n",
-       "1         2.186605  \n",
-       "2         5.081670  \n",
-       "3         2.716482  \n",
-       "4         2.347458  \n",
-       "5         3.965506  \n",
-       "6         3.872491  \n",
-       "7         2.660188  \n",
-       "8         1.845592  \n",
-       "9         0.588166  "
+       "   below_corrected_p  -log10(p-value)  \n",
+       "0               True         1.633101  \n",
+       "1               True         2.186605  \n",
+       "2               True         5.081670  \n",
+       "3               True         2.716482  \n",
+       "4               True         2.347458  \n",
+       "5               True         3.965506  \n",
+       "6               True         3.872491  \n",
+       "7               True         2.660188  \n",
+       "8               True         1.845592  \n",
+       "9              False         0.588166  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1370,7 +1381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1411,7 +1422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/phenotypic_consistency.ipynb
+++ b/examples/phenotypic_consistency.ipynb
@@ -718,7 +718,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72e631ce67b44d2f890735cc44c480d4",
+       "model_id": "03af9026665942efb864db6d5f6a16f8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -732,7 +732,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9e22a9580bac4c6a9134c8ac9dbc1169",
+       "model_id": "78fde7316fac4d94bcbb723186ae5765",
        "version_major": 2,
        "version_minor": 0
       },
@@ -939,7 +939,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f03f87b87d1c45549ec70867a939d998",
+       "model_id": "6f0e8d88d2fb41dca1b83a7c372738ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -953,7 +953,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4eed9e51bb454b48be43bb161a042c35",
+       "model_id": "b4dba4f9c8914cb2841ff93feae50dc8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -987,6 +987,7 @@
        "      <th></th>\n",
        "      <th>Metadata_target</th>\n",
        "      <th>mean_average_precision</th>\n",
+       "      <th>indices</th>\n",
        "      <th>p_value</th>\n",
        "      <th>corrected_p_value</th>\n",
        "      <th>below_p</th>\n",
@@ -999,6 +1000,7 @@
        "      <th>0</th>\n",
        "      <td>ADRA1A</td>\n",
        "      <td>0.250000</td>\n",
+       "      <td>[26, 45]</td>\n",
        "      <td>0.112414</td>\n",
        "      <td>0.186114</td>\n",
        "      <td>False</td>\n",
@@ -1009,6 +1011,7 @@
        "      <th>1</th>\n",
        "      <td>ADRA2A</td>\n",
        "      <td>0.250000</td>\n",
+       "      <td>[27, 46]</td>\n",
        "      <td>0.112414</td>\n",
        "      <td>0.186114</td>\n",
        "      <td>False</td>\n",
@@ -1019,6 +1022,7 @@
        "      <th>2</th>\n",
        "      <td>AURKA</td>\n",
        "      <td>0.625000</td>\n",
+       "      <td>[21, 22]</td>\n",
        "      <td>0.023976</td>\n",
        "      <td>0.103896</td>\n",
        "      <td>True</td>\n",
@@ -1029,6 +1033,7 @@
        "      <th>3</th>\n",
        "      <td>BIRC2</td>\n",
        "      <td>0.060662</td>\n",
+       "      <td>[23, 54]</td>\n",
        "      <td>0.380492</td>\n",
        "      <td>0.471085</td>\n",
        "      <td>False</td>\n",
@@ -1039,6 +1044,7 @@
        "      <th>4</th>\n",
        "      <td>CHRM1</td>\n",
        "      <td>0.098420</td>\n",
+       "      <td>[11, 28, 57]</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>False</td>\n",
@@ -1049,6 +1055,7 @@
        "      <th>5</th>\n",
        "      <td>CHRM2</td>\n",
        "      <td>0.098420</td>\n",
+       "      <td>[12, 29, 58]</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>False</td>\n",
@@ -1059,6 +1066,7 @@
        "      <th>6</th>\n",
        "      <td>CHRM3</td>\n",
        "      <td>0.098420</td>\n",
+       "      <td>[13, 30, 59]</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>False</td>\n",
@@ -1069,6 +1077,7 @@
        "      <th>7</th>\n",
        "      <td>CHRM4</td>\n",
        "      <td>0.098420</td>\n",
+       "      <td>[14, 31, 60]</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>False</td>\n",
@@ -1079,6 +1088,7 @@
        "      <th>8</th>\n",
        "      <td>CHRM5</td>\n",
        "      <td>0.098420</td>\n",
+       "      <td>[15, 32, 61]</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>0.492938</td>\n",
        "      <td>False</td>\n",
@@ -1089,6 +1099,7 @@
        "      <th>9</th>\n",
        "      <td>DRD2</td>\n",
        "      <td>0.750000</td>\n",
+       "      <td>[25, 33]</td>\n",
        "      <td>0.000670</td>\n",
        "      <td>0.004355</td>\n",
        "      <td>True</td>\n",
@@ -1100,29 +1111,29 @@
        "</div>"
       ],
       "text/plain": [
-       "  Metadata_target  mean_average_precision   p_value  corrected_p_value  \\\n",
-       "0          ADRA1A                0.250000  0.112414           0.186114   \n",
-       "1          ADRA2A                0.250000  0.112414           0.186114   \n",
-       "2           AURKA                0.625000  0.023976           0.103896   \n",
-       "3           BIRC2                0.060662  0.380492           0.471085   \n",
-       "4           CHRM1                0.098420  0.492938           0.492938   \n",
-       "5           CHRM2                0.098420  0.492938           0.492938   \n",
-       "6           CHRM3                0.098420  0.492938           0.492938   \n",
-       "7           CHRM4                0.098420  0.492938           0.492938   \n",
-       "8           CHRM5                0.098420  0.492938           0.492938   \n",
-       "9            DRD2                0.750000  0.000670           0.004355   \n",
+       "  Metadata_target  mean_average_precision       indices   p_value  \\\n",
+       "0          ADRA1A                0.250000      [26, 45]  0.112414   \n",
+       "1          ADRA2A                0.250000      [27, 46]  0.112414   \n",
+       "2           AURKA                0.625000      [21, 22]  0.023976   \n",
+       "3           BIRC2                0.060662      [23, 54]  0.380492   \n",
+       "4           CHRM1                0.098420  [11, 28, 57]  0.492938   \n",
+       "5           CHRM2                0.098420  [12, 29, 58]  0.492938   \n",
+       "6           CHRM3                0.098420  [13, 30, 59]  0.492938   \n",
+       "7           CHRM4                0.098420  [14, 31, 60]  0.492938   \n",
+       "8           CHRM5                0.098420  [15, 32, 61]  0.492938   \n",
+       "9            DRD2                0.750000      [25, 33]  0.000670   \n",
        "\n",
-       "   below_p  below_corrected_p  -log10(p-value)  \n",
-       "0    False              False         0.730220  \n",
-       "1    False              False         0.730220  \n",
-       "2     True              False         0.983402  \n",
-       "3    False              False         0.326901  \n",
-       "4    False              False         0.307208  \n",
-       "5    False              False         0.307208  \n",
-       "6    False              False         0.307208  \n",
-       "7    False              False         0.307208  \n",
-       "8    False              False         0.307208  \n",
-       "9     True               True         2.361012  "
+       "   corrected_p_value  below_p  below_corrected_p  -log10(p-value)  \n",
+       "0           0.186114    False              False         0.730220  \n",
+       "1           0.186114    False              False         0.730220  \n",
+       "2           0.103896     True              False         0.983402  \n",
+       "3           0.471085    False              False         0.326901  \n",
+       "4           0.492938    False              False         0.307208  \n",
+       "5           0.492938    False              False         0.307208  \n",
+       "6           0.492938    False              False         0.307208  \n",
+       "7           0.492938    False              False         0.307208  \n",
+       "8           0.492938    False              False         0.307208  \n",
+       "9           0.004355     True               True         2.361012  "
       ]
      },
      "execution_count": 6,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "copairs"
-version = "0.5.0"
+version = "0.5.1"
 description = "Find pairs and compute metrics between them"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/copairs/compute.py
+++ b/src/copairs/compute.py
@@ -398,7 +398,8 @@ def ap_contiguous(
     pr_k = tp / k
 
     # Calculate average precision scores for each profile
-    ap_scores = np.add.reduceat(pr_k * rel_k_list, cutoffs) / num_pos
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ap_scores = np.add.reduceat(pr_k * rel_k_list, cutoffs) / num_pos
 
     # Generate configurations (number of positive and total pairs)
     null_confs = np.stack([num_pos, counts], axis=1)

--- a/src/copairs/map/average_precision.py
+++ b/src/copairs/map/average_precision.py
@@ -66,7 +66,7 @@ def build_rank_lists(
     # Expand similarity scores to match the flattened pair indices
     sim_all = np.concatenate([np.repeat(pos_sims, 2), np.repeat(neg_sims, 2)])
 
-    # Sort by index (lexicographical order) and then by similarity (descending) 
+    # Sort by index (lexicographical order) and then by similarity (descending)
     # `1 - sim_all` ensures higher similarity values appear first, prioritizing
     # pairs with stronger similarity scores for ranking.
     # `ix` acts as a secondary criterion, ensuring consistent ordering of pairs

--- a/src/copairs/map/average_precision.py
+++ b/src/copairs/map/average_precision.py
@@ -66,7 +66,7 @@ def build_rank_lists(
     # Expand similarity scores to match the flattened pair indices
     sim_all = np.concatenate([np.repeat(pos_sims, 2), np.repeat(neg_sims, 2)])
 
-    # Sort by similarity (descending) and then by index (lexicographical order)
+    # Sort by index (lexicographical order) and then by similarity (descending) 
     # `1 - sim_all` ensures higher similarity values appear first, prioritizing
     # pairs with stronger similarity scores for ranking.
     # `ix` acts as a secondary criterion, ensuring consistent ordering of pairs

--- a/src/copairs/map/average_precision.py
+++ b/src/copairs/map/average_precision.py
@@ -1,6 +1,5 @@
 """Functions to compute average precision."""
 
-import itertools
 import logging
 from typing import List
 

--- a/src/copairs/map/map.py
+++ b/src/copairs/map/map.py
@@ -82,12 +82,12 @@ def mean_average_precision(
     logger.info("Computing p-values...")
 
     # Group by the specified metadata column(s) and calculate mean AP
-    map_scores = ap_scores.groupby(sameby, observed=True).agg(
+    map_scores = ap_scores.groupby(sameby, observed=True, as_index=False).agg(
         {
             "average_precision": ["mean", lambda x: list(x.index)],
         }
     )
-    map_scores.columns = ["mean_average_precision", "indices"]
+    map_scores.columns = sameby + ["mean_average_precision", "indices"]
 
     # Compute p-values for each group using the null distributions
     params = map_scores[["mean_average_precision", "indices"]]

--- a/src/copairs/map/map.py
+++ b/src/copairs/map/map.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ logger = logging.getLogger("copairs")
 
 def mean_average_precision(
     ap_scores: pd.DataFrame,
-    sameby,
+    sameby: List[str],
     null_size: int,
     threshold: float,
     seed: int,

--- a/src/copairs/map/multilabel.py
+++ b/src/copairs/map/multilabel.py
@@ -1,7 +1,7 @@
 """Functions to compute mAP with multilabel support."""
 
-import itertools
 import logging
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -68,12 +68,12 @@ def _build_rank_lists_multi(pos_pairs, pos_sims, pos_counts, negs_for):
 
 
 def average_precision(
-    meta,
-    feats,
-    pos_sameby,
-    pos_diffby,
-    neg_sameby,
-    neg_diffby,
+    meta: pd.DataFrame,
+    feats: pd.DataFrame,
+    pos_sameby: List[str],
+    pos_diffby: List[str],
+    neg_sameby: List[str],
+    neg_diffby: List[str],
     multilabel_col,
     batch_size=20000,
     distance="cosine",
@@ -98,7 +98,6 @@ def average_precision(
     pos_pairs, keys, pos_counts = find_pairs_multilabel(
         meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col
     )
-    total_counts = sum(pos_counts)
     if len(pos_pairs) == 0:
         raise UnpairedException("Unable to find positive pairs.")
 
@@ -142,7 +141,7 @@ def average_precision(
     results = pd.concat(results).reset_index(drop=True)
     meta = meta.drop(multilabel_col, axis=1)
     results = meta.merge(results, right_on="ix", left_index=True).drop("ix", axis=1)
-    results["n_pos_pairs"] = results["n_pos_pairs"].fillna(0).astype(np.int32)
-    results["n_total_pairs"] = results["n_total_pairs"].fillna(0).astype(np.int32)
+    results["n_pos_pairs"] = results["n_pos_pairs"].fillna(0).astype(np.uint32)
+    results["n_total_pairs"] = results["n_total_pairs"].fillna(0).astype(np.uint32)
     logger.info("Finished.")
     return results

--- a/src/copairs/map/multilabel.py
+++ b/src/copairs/map/multilabel.py
@@ -95,13 +95,17 @@ def average_precision(
     logger.info("Indexing metadata...")
 
     logger.info("Finding positive pairs...")
-    pos_pairs, keys, pos_counts = find_pairs_multilabel(meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col)
+    pos_pairs, keys, pos_counts = find_pairs_multilabel(
+        meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col
+    )
     total_counts = sum(pos_counts)
     if len(pos_pairs) == 0:
         raise UnpairedException("Unable to find positive pairs.")
 
     logger.info("Finding negative pairs...")
-    neg_pairs = find_pairs_multilabel(meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col)
+    neg_pairs = find_pairs_multilabel(
+        meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col
+    )
     if len(neg_pairs) == 0:
         raise UnpairedException("Unable to find any negative pairs.")
 
@@ -131,7 +135,7 @@ def average_precision(
                 "n_pos_pairs": null_confs_list[i][:, 0],
                 "n_total_pairs": null_confs_list[i][:, 1],
                 "ix": ix_list[i],
-                multilabel_col:key,
+                multilabel_col: key,
             }
         )
         results.append(result)

--- a/src/copairs/map/multilabel.py
+++ b/src/copairs/map/multilabel.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from copairs import compute
-from copairs.matching import UnpairedException, find_pairs
+from copairs.matching import UnpairedException, find_pairs_multilabel
 
 from .filter import evaluate_and_filter, flatten_str_list, validate_pipeline_input
 
@@ -95,13 +95,13 @@ def average_precision(
     logger.info("Indexing metadata...")
 
     logger.info("Finding positive pairs...")
-    pos_pairs = find_pairs(meta, sameby=pos_sameby, diffby=pos_diffby)
+    pos_pairs = find_pairs_multilabel(meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col)
     if len(pos_pairs) == 0:
         raise UnpairedException("Unable to find positive pairs.")
 
     logger.info("Finding negative pairs...")
     _, pos_counts = np.unique(pos_pairs, axis=0, return_counts=True)
-    neg_pairs = find_pairs(meta, sameby=neg_sameby, diffby=neg_diffby)
+    neg_pairs = find_pairs_multilabel(meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col)
     if len(neg_pairs) == 0:
         raise UnpairedException("Unable to find any negative pairs.")
 

--- a/src/copairs/map/multilabel.py
+++ b/src/copairs/map/multilabel.py
@@ -95,13 +95,17 @@ def average_precision(
     logger.info("Indexing metadata...")
 
     logger.info("Finding positive pairs...")
-    pos_pairs = find_pairs_multilabel(meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col)
+    pos_pairs = find_pairs_multilabel(
+        meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col
+    )
     if len(pos_pairs) == 0:
         raise UnpairedException("Unable to find positive pairs.")
 
     logger.info("Finding negative pairs...")
     _, pos_counts = np.unique(pos_pairs, axis=0, return_counts=True)
-    neg_pairs = find_pairs_multilabel(meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col)
+    neg_pairs = find_pairs_multilabel(
+        meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col
+    )
     if len(neg_pairs) == 0:
         raise UnpairedException("Unable to find any negative pairs.")
 

--- a/src/copairs/map/multilabel.py
+++ b/src/copairs/map/multilabel.py
@@ -95,17 +95,13 @@ def average_precision(
     logger.info("Indexing metadata...")
 
     logger.info("Finding positive pairs...")
-    pos_pairs = find_pairs_multilabel(
-        meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col
-    )
+    pos_pairs, keys, pos_counts = find_pairs_multilabel(meta, sameby=pos_sameby, diffby=pos_diffby, multilabel_col=multilabel_col)
+    total_counts = sum(pos_counts)
     if len(pos_pairs) == 0:
         raise UnpairedException("Unable to find positive pairs.")
 
     logger.info("Finding negative pairs...")
-    _, pos_counts = np.unique(pos_pairs, axis=0, return_counts=True)
-    neg_pairs = find_pairs_multilabel(
-        meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col
-    )
+    neg_pairs = find_pairs_multilabel(meta, sameby=neg_sameby, diffby=neg_diffby, multilabel_col=multilabel_col)
     if len(neg_pairs) == 0:
         raise UnpairedException("Unable to find any negative pairs.")
 
@@ -126,14 +122,16 @@ def average_precision(
 
     logger.info("Creating result DataFrame...")
     results = []
-    for i, key in enumerate(pos_pairs):
+    "Here the positive pairs are per-item inside multilabel_col"
+    # TODO Check if multi-label key is necessary
+    for i, key in enumerate(keys):
         result = pd.DataFrame(
             {
                 "average_precision": ap_scores_list[i],
                 "n_pos_pairs": null_confs_list[i][:, 0],
                 "n_total_pairs": null_confs_list[i][:, 1],
                 "ix": ix_list[i],
-                **{col: meta.iloc[key][col] for col in meta.columns},
+                multilabel_col:key,
             }
         )
         results.append(result)

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -1,5 +1,6 @@
 """Sample pairs with given column restrictions."""
 
+from copy import copy
 import itertools
 import logging
 import re
@@ -520,7 +521,7 @@ def find_pairs_multilabel(
     sameby: Union[str, ColumnList],
     diffby: Union[str, ColumnList],
     multilabel_col: str,
-) -> np.ndarray:
+) -> np.ndarray or tuple(np.ndarray, np.ndarray, np.ndarray):
     """
     Find pairs of rows in a DataFrame that have the same or different values in certain columns.
 
@@ -553,30 +554,56 @@ def find_pairs_multilabel(
     df = dframe.reset_index()
 
     if multilabel_col in sameby:
+        sameby = copy(sameby)
         sameby.remove(multilabel_col)
-        shared_item = True
+        shared_item = ""
     else:
+        diffby = copy(diffby)
         diffby.remove(multilabel_col)
-        shared_item = False
+        shared_item = "NOT"
 
     with duckdb.connect(":memory:"):
         result = duckdb.sql(
             "SELECT * "
-            f" FROM (select *,CAST(len(list_intersect(A.{multilabel_col},B.{multilabel_col})) AS BOOL)"
-            " AS shared_item "
+            " FROM (SELECT *,"
+            f"list_intersect(A.{multilabel_col},B.{multilabel_col}) AS shared_items"
             " FROM df A JOIN df B ON A.index < B.index)"
-            f" WHERE shared_item = {shared_item}"
+            f" WHERE {shared_item} len(shared_items) > 0"
         )
-
         if len(sameby) or len(diffby):
             monolabel_result = find_pairs(df, sameby, diffby).T
             result = duckdb.sql(
                 f"SELECT index, index_1"
                 " FROM result A JOIN monolabel_result B"
-                " ON A.index = B.column0 "
-                "AND A.index_1 = B.column1"
+                " ON A.index = B.column0"
+                " AND A.index_1 = B.column1"
             )
 
-    index_d = result.fetchnumpy()
-    result = np.array((index_d["index"], index_d["index_1"]), dtype=np.uint32).T
+        if shared_item == "": # If multilabel_col is in sameby
+            # We assign a pair if any of the other items in the list is a pair too
+            unnested = duckdb.sql("SELECT *,UNNEST(shared_items) AS matched_item FROM result")
+            string = ("SELECT * FROM unnested A"
+                      " NATURAL JOIN (SELECT matched_item,COUNT(matched_item)"
+                      " AS c FROM unnested GROUP BY matched_item) B")
+            result = duckdb.sql(string)
+
+            # Sort them to match the original implementation
+            result = duckdb.sql("SELECT * FROM result ORDER BY matched_item")
+
+            # Format results to return pairs, keys and counts
+
+            # Sorted pairs of indices (we select to reduce memory footprint)
+            pairs = duckdb.sql("SELECT index,index_1 FROM result")
+            pairs_np = pairs.fetchnumpy()
+            
+            # Keys are the items inside multilabel col
+            # Counts are the number of occurrences of each one
+            keys_counts = duckdb.sql("SELECT distinct matched_item,c FROM result")
+            keys_counts_np = keys_counts.fetchnumpy()
+            
+            result = (np.array([pairs_np[f"index{k}"] for k in ("","_1")], dtype=np.uint32).T, *[keys_counts_np[k] for k in ("matched_item", "c")])
+        else: # if multilabel_col is in diffby return only the index
+            index_d = result.fetchnumpy()
+            result = np.array([index_d[k] for k in ("index","index_1")], dtype=np.uint32).T
+
     return result

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -585,22 +585,21 @@ def find_pairs_multilabel(
             string = ("SELECT * FROM unnested A"
                       " NATURAL JOIN (SELECT matched_item,COUNT(matched_item)"
                       " AS c FROM unnested GROUP BY matched_item) B")
-            result = duckdb.sql(string)
+            results = duckdb.sql(string)
 
             # Sort them to match the original implementation
-            result = duckdb.sql("SELECT * FROM result ORDER BY matched_item")
-
-            # Format results to return pairs, keys and counts
+            results = duckdb.sql("SELECT * FROM results ORDER BY matched_item")
 
             # Sorted pairs of indices (we select to reduce memory footprint)
-            pairs = duckdb.sql("SELECT index,index_1 FROM result")
+            pairs = duckdb.sql("SELECT index,index_1 FROM results")
             pairs_np = pairs.fetchnumpy()
             
             # Keys are the items inside multilabel col
             # Counts are the number of occurrences of each one
-            keys_counts = duckdb.sql("SELECT distinct matched_item,c FROM result")
+            # It is important to sort again!
+            keys_counts = duckdb.sql("SELECT distinct matched_item,c FROM results ORDER BY matched_item")
             keys_counts_np = keys_counts.fetchnumpy()
-            
+
             result = (np.array([pairs_np[f"index{k}"] for k in ("","_1")], dtype=np.uint32).T, *[keys_counts_np[k] for k in ("matched_item", "c")])
         else: # if multilabel_col is in diffby return only the index
             index_d = result.fetchnumpy()

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -577,7 +577,6 @@ def find_pairs_multilabel(
                 "AND A.index_1 = B.column1"
             )
 
-        index_d = result.fetchnumpy()
-        result = np.array((index_d["index"], index_d["index_1"]), dtype=np.uint32).T
-
+    index_d = result.fetchnumpy()
+    result = np.array((index_d["index"], index_d["index_1"]), dtype=np.uint32).T
     return result

--- a/tests/test_matching_multilabel.py
+++ b/tests/test_matching_multilabel.py
@@ -51,6 +51,8 @@ def check_naive(dframe, sameby, diffby, multilabel_col):
     """Check find_pairs_multilabel and naive generate same pairs."""
     gt_pairs = get_naive_pairs(dframe, sameby, diffby, multilabel_col)
     vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
+    if multilabel_col in sameby:  # output is different if based on multilabel_col
+        vals = vals[0]
     vals = pd.DataFrame(vals, columns=["index_x", "index_y"])
     vals = vals.sort_values(["index_x", "index_y"]).reset_index(drop=True)
     vals = set(vals.apply(frozenset, axis=1))


### PR DESCRIPTION
Running both phenotypic activity and consistency examples fails in the new version. 

In the activity example is was due to the bug introduced in the earlier version, fixed in a8a35c57c7f675b474f7e99e94cc5bff272ec187.

@afermg phenotypic consistency returns incorrect result for multilabel AP calculation, which in turn fails mAP calculation—can you take a look?