### PR TITLE
Make progress bar an optional argument

### DIFF
--- a/src/copairs/compute.py
+++ b/src/copairs/compute.py
@@ -4,15 +4,16 @@ import itertools
 import os
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Callable, Tuple, Union, Optional
+from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
-from tqdm.autonotebook import tqdm
-from scipy.spatial.distance import cdist
 from scipy.spatial.distance import _METRICS_NAMES as SCIPY_METRICS_NAMES
+from scipy.spatial.distance import cdist
 
 
-def parallel_map(par_func: Callable[[int], None], items: np.ndarray) -> None:
+def parallel_map(
+    par_func: Callable[[int], None], items: np.ndarray, progress_bar: bool = True
+) -> None:
     """Execute a function in parallel over a list of items.
 
     This function uses a thread pool to process items in parallel, with progress
@@ -41,8 +42,12 @@ def parallel_map(par_func: Callable[[int], None], items: np.ndarray) -> None:
         # Map the function to items with unordered execution for better efficiency
         tasks = pool.imap_unordered(par_func, items, chunksize=chunksize)
 
-        # Display progress using tqdm
-        for _ in tqdm(tasks, total=len(items), leave=False):
+        if progress_bar:
+            # Display progress using tqdm
+            from tqdm.autonotebook import tqdm
+
+            tasks = tqdm(tasks, total=len(items), leave=False)
+        for _ in tasks:
             pass
 
 

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -11,7 +11,6 @@ from typing import Dict, Sequence, Set, Union
 import duckdb
 import numpy as np
 import pandas as pd
-from tqdm.auto import tqdm
 
 logger = logging.getLogger("copairs")
 ColumnList = Union[Sequence[str], pd.Index]
@@ -444,10 +443,19 @@ class MatcherMultilabel:
         id1, id2 = self.original_index[list(null_pair)].values
         return id1, id2
 
-    def get_null_pairs(self, diffby: ColumnList, size: int, n_tries=5):
+    def get_null_pairs(
+        self, diffby: ColumnList, size: int, n_tries=5, progress_bar: bool = True
+    ):
         """Sample multiple null pairs at the same time."""
         null_pairs = []
-        for _ in tqdm(range(size)):
+
+        iterator = range(size)
+        if progress_bar:
+            from tqdm.auto import tqdm
+
+            iterator = tqdm(iterator)
+
+        for _ in iterator:
             null_pairs.append(self.matcher.sample_null_pair(diffby, n_tries))
         null_pairs = np.array(null_pairs)
         null_pairs[:, 0] = self.original_index[null_pairs[:, 0]].values


### PR DESCRIPTION

Following up from #67, I moved the tqdm imports inside if-else statements so it is only imported when necessary (in case we would like to make it an optional dependency).

Potential additional changes:
- Propagate the progress_bar argument a few levels up to expose it to the documented API.
- Make tqdm an optional dependency instead of a required one.


Tests run fine:
```
.venv ❯ pytest
================================ test session starts =================================platform linux -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/amunoz/projects/copairs
configfile: pyproject.toml
plugins: anyio-4.8.0
collected 43 items                                                                   

tests/test_build_rank_multilabel.py .                                          [  2%]
tests/test_compute.py ........                                                 [ 20%]
tests/test_map.py .......                                                      [ 37%]
tests/test_map_filter.py ....                                                  [ 46%]
tests/test_matching.py .........                                               [ 67%]
tests/test_matching_any.py ....                                                [ 76%]
tests/test_matching_multilabel.py ......                                       [ 90%]
tests/test_reference_index.py .                                                [ 93%]
tests/test_replicating.py ...                                                  [100%]

=========================== 43 passed in 73.17s (0:01:13) ============================
```

Some imports were automatically sorted, sorry about that. 

LMK if any more changes are desired.
Alán
