### PR TITLE
fix(matching): correct diffby tuple conversion in _validate

### DIFF
--- a/examples/finding_pairs.ipynb
+++ b/examples/finding_pairs.ipynb
@@ -11,7 +11,7 @@
     "Specifically, this is used in calculation of mAP for profile strength and similarity assesement.\n",
     "\n",
     "Citation:\n",
-    "> Kalinin, A. A. et al. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, 2024-04, (2024)."
+    "> Kalinin, A.A., Arevalo, J., Serrano, E., Vulliard, L., Tsang, H., Bornholdt, M., Muñoz, A.F., Sivagurunathan, S., Rajwa, B., Carpenter, A.E., Way, G.P. and Singh, S., 2025. A versatile information retrieval framework for evaluating profile strength and similarity. _Nature Communications_ 16, 5181. doi:10.1038/s41467-025-60306-2"
    ]
   },
   {

--- a/examples/finding_pairs.ipynb
+++ b/examples/finding_pairs.ipynb
@@ -21,6 +21,7 @@
    "outputs": [],
    "source": [
     "import random\n",
+    "\n",
     "import pandas as pd\n",
     "\n",
     "from copairs import Matcher, MatcherMultilabel"

--- a/examples/null_size.ipynb
+++ b/examples/null_size.ipynb
@@ -578,7 +578,7 @@
     "\n",
     "Finding a `null_size` that works for a particular dataset means balancing between test resolution (for example, being able to tell apart vary small p-values) and compute. We provided `null_size` values for each real-world dataset in Supplemental Materials to our paper—please refer to:\n",
     "\n",
-    "> Kalinin, A. A. et al. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, 2024-04, (2024)."
+    "> Kalinin, A.A., Arevalo, J., Serrano, E., Vulliard, L., Tsang, H., Bornholdt, M., Muñoz, A.F., Sivagurunathan, S., Rajwa, B., Carpenter, A.E., Way, G.P. and Singh, S., 2025. A versatile information retrieval framework for evaluating profile strength and similarity. _Nature Communications_ 16, 5181. doi:10.1038/s41467-025-60306-2"
    ]
   },
   {

--- a/examples/null_size.ipynb
+++ b/examples/null_size.ipynb
@@ -15,8 +15,8 @@
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from scipy.special import comb\n",
     "import matplotlib.pyplot as plt\n",
+    "from scipy.special import comb\n",
     "\n",
     "from copairs import map"
    ]

--- a/examples/phenotypic_activity.ipynb
+++ b/examples/phenotypic_activity.ipynb
@@ -36,7 +36,7 @@
     "The resulting perturbation mAP score reflects the average extent to which its replicate profiles are more similar to each other compared to control profiles (Figure 1E).\n",
     "\n",
     "Citation:\n",
-    "> Kalinin, A. A. et al. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, 2024-04, (2024)."
+    "> Kalinin, A.A., Arevalo, J., Serrano, E., Vulliard, L., Tsang, H., Bornholdt, M., Muñoz, A.F., Sivagurunathan, S., Rajwa, B., Carpenter, A.E., Way, G.P. and Singh, S., 2025. A versatile information retrieval framework for evaluating profile strength and similarity. _Nature Communications_ 16, 5181. doi:10.1038/s41467-025-60306-2"
    ]
   },
   {

--- a/examples/phenotypic_activity.ipynb
+++ b/examples/phenotypic_activity.ipynb
@@ -46,10 +46,10 @@
    "outputs": [],
    "source": [
     "# these imports are only needed for showing Figure 1 from the paper\n",
-    "import requests\n",
     "from io import BytesIO\n",
     "from pathlib import Path\n",
     "\n",
+    "import requests\n",
     "from PIL import Image\n",
     "from IPython.display import display"
    ]

--- a/examples/phenotypic_consistency.ipynb
+++ b/examples/phenotypic_consistency.ipynb
@@ -35,7 +35,7 @@
     "The resulting mAP score for a group of perturbations reflects the average extent to which members of this group are more similar to each other compared to other groups (see Figure 1F).\n",
     "\n",
     "Citation:\n",
-    "> Kalinin, A. A. et al. A versatile information retrieval framework for evaluating profile strength and similarity. bioRxiv, 2024-04, (2024)."
+    "> Kalinin, A.A., Arevalo, J., Serrano, E., Vulliard, L., Tsang, H., Bornholdt, M., Muñoz, A.F., Sivagurunathan, S., Rajwa, B., Carpenter, A.E., Way, G.P. and Singh, S., 2025. A versatile information retrieval framework for evaluating profile strength and similarity. _Nature Communications_ 16, 5181. doi:10.1038/s41467-025-60306-2"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,13 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.ruff.lint]
-select = ["D"]
+select = ["D", "I"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.isort]
+length-sort = true
 
 [dependency-groups]
 dev = [

--- a/src/copairs/compute.py
+++ b/src/copairs/compute.py
@@ -1,10 +1,10 @@
 """Functions to compute distances and ranks using numpy operations."""
 
-import itertools
 import os
-from multiprocessing.pool import ThreadPool
+import itertools
+from typing import Tuple, Union, Callable, Optional
 from pathlib import Path
-from typing import Callable, Optional, Tuple, Union
+from multiprocessing.pool import ThreadPool
 
 import numpy as np
 from scipy.spatial.distance import _METRICS_NAMES as SCIPY_METRICS_NAMES

--- a/src/copairs/map/__init__.py
+++ b/src/copairs/map/__init__.py
@@ -1,7 +1,7 @@
 """Module to compute mAP-based metrics."""
 
 from . import multilabel
-from .average_precision import average_precision
 from .map import mean_average_precision
+from .average_precision import average_precision
 
 __all__ = ["mean_average_precision", "multilabel", "average_precision"]

--- a/src/copairs/map/average_precision.py
+++ b/src/copairs/map/average_precision.py
@@ -1,7 +1,7 @@
 """Functions to compute average precision."""
 
 import logging
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -9,7 +9,7 @@ import pandas as pd
 from copairs import compute
 from copairs.matching import UnpairedException, find_pairs
 
-from .filter import evaluate_and_filter, flatten_str_list, validate_pipeline_input
+from .filter import flatten_str_list, evaluate_and_filter, validate_pipeline_input
 
 logger = logging.getLogger("copairs")
 

--- a/src/copairs/map/filter.py
+++ b/src/copairs/map/filter.py
@@ -1,7 +1,7 @@
 """Functions to support query-like syntax when finding the matches."""
 
-import itertools
 import re
+import itertools
 from typing import List, Tuple
 
 import numpy as np

--- a/src/copairs/map/map.py
+++ b/src/copairs/map/map.py
@@ -1,10 +1,10 @@
 """Functions to compute mean average precision."""
 
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from os import cpu_count
+from typing import List, Union, Optional
 from pathlib import Path
-from typing import List, Optional, Union
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pandas as pd

--- a/src/copairs/map/multilabel.py
+++ b/src/copairs/map/multilabel.py
@@ -1,7 +1,7 @@
 """Functions to compute mAP with multilabel support."""
 
 import logging
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -9,7 +9,7 @@ import pandas as pd
 from copairs import compute
 from copairs.matching import UnpairedException, find_pairs_multilabel
 
-from .filter import evaluate_and_filter, flatten_str_list, validate_pipeline_input
+from .filter import flatten_str_list, evaluate_and_filter, validate_pipeline_input
 
 logger = logging.getLogger("copairs")
 

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -5,11 +5,11 @@ import logging
 import itertools
 from copy import copy
 from math import comb
+from typing import Set, Dict, Tuple, Union, Sequence
 from collections import namedtuple
-from typing import Dict, Sequence, Set, Tuple, Union
 
-import duckdb
 import numpy as np
+import duckdb
 import pandas as pd
 
 logger = logging.getLogger("copairs")

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -2,6 +2,7 @@
 
 import re
 import logging
+import warnings
 import itertools
 from copy import copy
 from math import comb
@@ -519,8 +520,18 @@ def find_pairs(
 
 def _validate(sameby, diffby):
     if isinstance(sameby, str):
+        warnings.warn(
+            "Passing strings to 'sameby' is deprecated and will be removed in v0.5.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         sameby = (sameby,)
     if isinstance(diffby, str):
+        warnings.warn(
+            "Passing strings to 'diffby' is deprecated and will be removed in v0.5.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         diffby = (diffby,)
 
     if not (len(sameby) or len(diffby)):

--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -1,12 +1,12 @@
 """Sample pairs with given column restrictions."""
 
-import itertools
-import logging
 import re
-from collections import namedtuple
+import logging
+import itertools
 from copy import copy
 from math import comb
-from typing import Dict, Optional, Sequence, Set, Union
+from collections import namedtuple
+from typing import Dict, Sequence, Set, Tuple, Union
 
 import duckdb
 import numpy as np
@@ -366,7 +366,8 @@ class Matcher:
                     continue
                 mapper = self.reverse[col]
                 mapped.append(mapper[val])
-            valid = valid - set.intersection(*mapped)
+            if mapped:
+                valid = valid - set.intersection(*mapped)
         return valid
 
     def _get_full_pairs(self, mapper):
@@ -520,7 +521,7 @@ def _validate(sameby, diffby):
     if isinstance(sameby, str):
         sameby = (sameby,)
     if isinstance(diffby, str):
-        sameby = (diffby,)
+        diffby = (diffby,)
 
     if not (len(sameby) or len(diffby)):
         raise ValueError("at least one should be provided")
@@ -533,7 +534,7 @@ def find_pairs_multilabel(
     sameby: Union[str, ColumnList],
     diffby: Union[str, ColumnList],
     multilabel_col: str,
-) -> np.ndarray or tuple(np.ndarray, np.ndarray, np.ndarray):
+) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray, np.ndarray]]:
     """
     Find pairs of rows in a DataFrame that have the same or different values in certain columns.
 
@@ -559,6 +560,10 @@ def find_pairs_multilabel(
     -----
     The function asserts that `multilabel_col` is present in either `sameby` or `diffby`.
     """
+    sameby, diffby = _validate(sameby, diffby)
+    sameby = list(sameby)
+    diffby = list(diffby)
+
     assert (multilabel_col in sameby) or (multilabel_col in diffby), (
         f"Missing {multilabel_col} in sameby and diffby"
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 """Helper functions for testing."""
 
-from itertools import product
 from typing import Dict
+from itertools import product
 
 import numpy as np
 import pandas as pd

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -7,9 +7,9 @@ from sklearn.metrics import average_precision_score
 
 from copairs import compute
 from copairs.map import average_precision
-from copairs.map.multilabel import average_precision as multilabel_average_precision
-from copairs.matching import UnpairedException
 from tests.helpers import simulate_random_dframe
+from copairs.matching import UnpairedException
+from copairs.map.multilabel import average_precision as multilabel_average_precision
 
 SEED = 0
 

--- a/tests/test_map_filter.py
+++ b/tests/test_map_filter.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pytest
 
-from copairs.map.filter import evaluate_and_filter
 from tests.helpers import simulate_random_dframe
+from copairs.map.filter import evaluate_and_filter
 
 SEED = 0
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from copairs.matching import find_pairs
+from copairs.matching import find_pairs, _validate
 from tests.helpers import create_dframe, simulate_plates, simulate_random_dframe
 
 SEED = 0
@@ -123,6 +123,13 @@ def test_raise_no_params():
     dframe = create_dframe(3, 10)
     with pytest.raises(ValueError, match="at least one should be provided"):
         find_pairs(dframe, [], [])
+
+
+def test_validate_string_inputs():
+    """_validate should convert string inputs to tuples."""
+    sameby, diffby = _validate("c", "p")
+    assert sameby == ("c",)
+    assert diffby == ("p",)
 
 
 def assert_sameby_diffby(dframe: pd.DataFrame, pairs: dict, sameby, diffby):

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -6,8 +6,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from copairs.matching import find_pairs, _validate
 from tests.helpers import create_dframe, simulate_plates, simulate_random_dframe
+from copairs.matching import _validate, find_pairs
 
 SEED = 0
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -127,7 +127,8 @@ def test_raise_no_params():
 
 def test_validate_string_inputs():
     """_validate should convert string inputs to tuples."""
-    sameby, diffby = _validate("c", "p")
+    with pytest.deprecated_call():
+        sameby, diffby = _validate("c", "p")
     assert sameby == ("c",)
     assert diffby == ("p",)
 

--- a/tests/test_matching_multilabel.py
+++ b/tests/test_matching_multilabel.py
@@ -1,6 +1,7 @@
 """Tests for the multilabel matching implementation."""
 
 import pandas as pd
+import pytest
 
 from tests.helpers import simulate_random_plates
 from copairs.matching import find_pairs_multilabel
@@ -160,7 +161,8 @@ def test_accepts_string_inputs():
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
 
     gt_pairs = get_naive_pairs(dframe, [sameby], [diffby], multilabel_col)
-    vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
+    with pytest.deprecated_call():
+        vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
     if multilabel_col == sameby:
         vals = vals[0]
     vals = pd.DataFrame(vals, columns=["index_x", "index_y"])

--- a/tests/test_matching_multilabel.py
+++ b/tests/test_matching_multilabel.py
@@ -2,8 +2,8 @@
 
 import pandas as pd
 
-from copairs.matching import find_pairs_multilabel
 from tests.helpers import simulate_random_plates
+from copairs.matching import find_pairs_multilabel
 
 SEED = 42
 

--- a/tests/test_matching_multilabel.py
+++ b/tests/test_matching_multilabel.py
@@ -131,3 +131,39 @@ def test_only_sameby_many_cols():
     )
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
     check_naive(dframe, sameby, diffby, multilabel_col)
+
+
+def test_accepts_tuples_inputs():
+    """find_pairs_multilabel should accept tuples for sameby and diffby."""
+    multilabel_col = "c"
+    sameby = ("c",)
+    diffby = ("p", "w")
+    dframe = simulate_random_plates(
+        n_compounds=4, n_replicates=5, plate_size=5, sameby=sameby, diffby=diffby
+    )
+    dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
+    check_naive(dframe, sameby, diffby, multilabel_col)
+
+
+def test_accepts_string_inputs():
+    """find_pairs_multilabel should accept strings for sameby and diffby."""
+    multilabel_col = "c"
+    sameby = "c"
+    diffby = "p"
+    dframe = simulate_random_plates(
+        n_compounds=4,
+        n_replicates=5,
+        plate_size=5,
+        sameby=[sameby],
+        diffby=[diffby],
+    )
+    dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
+
+    gt_pairs = get_naive_pairs(dframe, [sameby], [diffby], multilabel_col)
+    vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
+    if multilabel_col == sameby:
+        vals = vals[0]
+    vals = pd.DataFrame(vals, columns=["index_x", "index_y"])
+    vals = vals.sort_values(["index_x", "index_y"]).reset_index(drop=True)
+
+    assert set(vals.apply(frozenset, axis=1)) == set(gt_pairs.apply(frozenset, axis=1))

--- a/tests/test_reference_index.py
+++ b/tests/test_reference_index.py
@@ -1,12 +1,12 @@
 """Tests for assign reference index helper function."""
 
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
 
 from copairs.map import average_precision
-from copairs.matching import assign_reference_index
 from tests.helpers import simulate_random_dframe
+from copairs.matching import assign_reference_index
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in divide")

--- a/tests/test_replicating.py
+++ b/tests/test_replicating.py
@@ -3,12 +3,12 @@
 from numpy.random import default_rng
 
 from copairs import Matcher
+from tests.helpers import create_dframe
 from copairs.replicating import (
-    corr_between_replicates,
     corr_from_pairs,
     correlation_test,
+    corr_between_replicates,
 )
-from tests.helpers import create_dframe
 
 SEED = 0
 


### PR DESCRIPTION
Fixes single-column diffby defined by passing a string instead of an array