### PR TITLE
Fixing argument error. Argument used as if positional instead of keyw…

### DIFF
--- a/src/copairs/compute.py
+++ b/src/copairs/compute.py
@@ -606,7 +606,7 @@ def p_values(
     confs, rev_ix = np.unique(null_confs, axis=0, return_inverse=True)
 
     # Generate null distributions for each unique configuration
-    null_dists = get_null_dists(confs, null_size, seed, progress_bar)
+    null_dists = get_null_dists(confs, null_size, seed, progress_bar=progress_bar)
 
     # Sort null distributions for efficient p-value computation
     null_dists.sort(axis=1)


### PR DESCRIPTION
Got a silly error due to miss match in positional and keyword argument. 

The function expects: 
```def get_null_dists(confs, null_size, seed, cache_dir=None, progress_bar=False):```

But got called without specifying `cashe_dir`.
```get_null_dists(confs, null_size, seed, progress_bar)```

Thus, resulting in cache_dir being set to a progress bar. 

Simply adding the keyword to fix this. But we might want to include 'cache_dir' in the function call, although it is not available in `p_values` at the moment. 