### PR TITLE
Add Dependabot configuration for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# GitHub Dependabot configuration
+# Note: there is no interaction between this
+# configuration and dependabot security updates.
+# See here for more information:
+# https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates#about-dependabot-security-updates
+
+version: 2
+updates:
+  # GitHub Actions checks
+  # See here for more information:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
+      # Check for updates to GitHub Actions every month
       interval: "monthly"


### PR DESCRIPTION
This PR adds a Dependabot configuration to help keep GH actions updated on a monthly basis. Specifically this helps to update things like `actions/checkout@v4` (which is currently out of date in this project). After merging this PR the project will see Dependabot open PR's for each action which needs to be updated.