### PR TITLE
Fix silent_thread_map passing invalid 'leave' kwarg

### DIFF
--- a/src/copairs/map/map.py
+++ b/src/copairs/map/map.py
@@ -108,12 +108,15 @@ def mean_average_precision(
 
     if progress_bar:
         from tqdm.contrib.concurrent import thread_map
-    else:
-        thread_map = silent_thread_map
 
-    map_scores["p_value"] = thread_map(
-        get_p_value, params.values, leave=False, max_workers=max_workers
-    )
+        p_values = thread_map(
+            get_p_value, params.values, leave=False, max_workers=max_workers
+        )
+    else:
+        p_values = silent_thread_map(
+            get_p_value, params.values, max_workers=max_workers
+        )
+    map_scores["p_value"] = p_values
 
     # Perform multiple testing correction on p-values
     reject, pvals_corrected, alphacSidak, alphacBonf = multipletests(
@@ -150,6 +153,5 @@ def silent_thread_map(fn, *iterables, **kwargs):
     kwargs = kwargs.copy()
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
     chunksize = kwargs.pop("chunksize", 1)
-    kwargs.pop("leave", None)  # tqdm-specific arg, not used by ThreadPoolExecutor
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
         return list(ex.map(fn, *iterables, chunksize=chunksize, **kwargs))

--- a/src/copairs/map/map.py
+++ b/src/copairs/map/map.py
@@ -150,5 +150,6 @@ def silent_thread_map(fn, *iterables, **kwargs):
     kwargs = kwargs.copy()
     max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
     chunksize = kwargs.pop("chunksize", 1)
+    kwargs.pop("leave", None)  # tqdm-specific arg, not used by ThreadPoolExecutor
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
         return list(ex.map(fn, *iterables, chunksize=chunksize, **kwargs))

--- a/tests/test_normalization_integration.py
+++ b/tests/test_normalization_integration.py
@@ -151,3 +151,30 @@ def test_mean_average_precision_with_normalization():
             result["treatment"] == treatment, "mean_normalized_average_precision"
         ].values[0]
         assert abs(actual_norm_map - expected_norm_map) < 0.001
+
+
+def test_mean_average_precision_no_progress_bar():
+    """Test that mean_average_precision works with progress_bar=False."""
+    from copairs.map.map import mean_average_precision
+
+    ap_scores = pd.DataFrame(
+        {
+            "treatment": ["A", "A", "B", "B"],
+            "average_precision": [0.8, 0.7, 0.6, 0.5],
+            "normalized_average_precision": [0.6, 0.5, 0.4, 0.3],
+            "n_pos_pairs": [10, 10, 8, 8],
+            "n_total_pairs": [50, 50, 40, 40],
+        }
+    )
+
+    # This should not raise TypeError about 'leave' argument
+    result = mean_average_precision(
+        ap_scores=ap_scores,
+        sameby=["treatment"],
+        null_size=100,
+        threshold=0.05,
+        seed=42,
+        progress_bar=False,
+    )
+
+    assert len(result) == 2


### PR DESCRIPTION
## Summary
- Fix `TypeError` when calling `mean_average_precision` with `progress_bar=False`
- The `leave` kwarg (tqdm-specific) was being passed to `ThreadPoolExecutor.map()` which doesn't accept it
- Added regression test

## Test plan
- [x] `uv run pytest` passes (62 tests)
- [x] `uv run ruff check src/ tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)