### PR TITLE
fix: replace diskcache with atomic file-per-key cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "tqdm",
   "statsmodels",
   "duckdb>=1.4.0",
-  "diskcache",
 ]
 
 [project.optional-dependencies]

--- a/src/copairs/compute.py
+++ b/src/copairs/compute.py
@@ -6,8 +6,9 @@ from typing import Tuple, Union, Callable, Optional
 from pathlib import Path
 from multiprocessing.pool import ThreadPool
 
+import tempfile
+
 import numpy as np
-import diskcache
 from scipy.spatial.distance import _METRICS_NAMES as SCIPY_METRICS_NAMES
 from scipy.spatial.distance import cdist
 
@@ -460,14 +461,42 @@ def random_ap(num_perm: int, num_pos: int, total: int, seed: int):
     return null_dist
 
 
+def _cache_read(path: Path) -> Optional[np.ndarray]:
+    """Read a cached .npy file, returning None on any corruption or absence."""
+    try:
+        return np.load(path)
+    except (FileNotFoundError, ValueError, EOFError, OSError):
+        return None
+
+
+def _cache_write(path: Path, arr: np.ndarray) -> None:
+    """Write a .npy file atomically via temp file + os.replace.
+
+    os.replace is atomic on POSIX (same filesystem), so concurrent readers
+    see either the old complete file or the new complete file, never a
+    partial write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".npy")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            np.save(f, arr)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
 def null_dist_cached(
     num_pos: int, total: int, seed: int, null_size: int, cache_dir: Path
 ) -> np.ndarray:
     """Generate or retrieve a cached null distribution for a given configuration.
 
-    This function calculates a null distribution for a specified number of positive
-    pairs (`num_pos`) and total pairs (`total`). It uses diskcache (SQLite-backed)
-    for process-safe concurrent caching.
+    Each (num_pos, total) pair is cached as an individual .npy file. Reads
+    are lock-free (just np.load), and writes use atomic rename to prevent
+    corruption from concurrent workers.
 
     Parameters
     ----------
@@ -490,12 +519,11 @@ def null_dist_cached(
     if seed is None:
         return random_ap(null_size, num_pos, total, seed)
 
-    key = f"n{total}_k{num_pos}"
-    with diskcache.Cache(str(cache_dir)) as cache:
-        null_dist = cache.get(key)
-        if null_dist is None:
-            null_dist = random_ap(null_size, num_pos, total, seed)
-            cache.set(key, null_dist)
+    path = cache_dir / f"n{total}_k{num_pos}.npy"
+    null_dist = _cache_read(path)
+    if null_dist is None:
+        null_dist = random_ap(null_size, num_pos, total, seed)
+        _cache_write(path, null_dist)
     return null_dist
 
 
@@ -526,32 +554,26 @@ def get_null_dists(
         A 2D array where each row corresponds to a null distribution for a specific
         configuration.
     """
-    # Define the directory for caching null distributions
     cache_dir = Path.home() / ".copairs" if cache_dir is None else Path(cache_dir)
     cache_dir = cache_dir / f"seed{seed}" / f"ns{null_size}"
+    cache_dir.mkdir(parents=True, exist_ok=True)
 
-    # Number of configurations and random seeds for each configuration
     num_confs = len(confs)
     rng = np.random.default_rng(seed)
     seeds = rng.integers(8096, size=num_confs)
 
-    # Initialize an array to store null distributions
     null_dists = np.empty([len(confs), null_size], dtype=np.float32)
 
-    # Open one shared cache for all threads
-    with diskcache.Cache(str(cache_dir)) as cache:
+    def par_func(i):
+        num_pos, total = confs[i]
+        path = cache_dir / f"n{total}_k{num_pos}.npy"
+        null_dist = _cache_read(path)
+        if null_dist is None:
+            null_dist = random_ap(null_size, num_pos, total, seeds[i])
+            _cache_write(path, null_dist)
+        null_dists[i] = null_dist
 
-        def par_func(i):
-            num_pos, total = confs[i]
-            key = f"n{total}_k{num_pos}"
-            null_dist = cache.get(key)
-            if null_dist is None:
-                null_dist = random_ap(null_size, num_pos, total, seeds[i])
-                cache.set(key, null_dist)
-            null_dists[i] = null_dist
-
-        # Parallelize the generation of null distributions
-        parallel_map(par_func, np.arange(num_confs), progress_bar)
+    parallel_map(par_func, np.arange(num_confs), progress_bar)
 
     return null_dists
 

--- a/src/copairs/compute.py
+++ b/src/copairs/compute.py
@@ -1,12 +1,11 @@
 """Functions to compute distances and ranks using numpy operations."""
 
 import os
+import tempfile
 import itertools
 from typing import Tuple, Union, Callable, Optional
 from pathlib import Path
 from multiprocessing.pool import ThreadPool
-
-import tempfile
 
 import numpy as np
 from scipy.spatial.distance import _METRICS_NAMES as SCIPY_METRICS_NAMES

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -207,15 +207,18 @@ def test_null_dist_cached():
     with tempfile.TemporaryDirectory() as tmpdir:
         cache_dir = Path(tmpdir)
 
-        # Generate null distribution with caching
         null_dist = compute.null_dist_cached(
             num_pos=5, total=20, seed=42, null_size=100, cache_dir=cache_dir
         )
 
-        # Check it created a valid distribution
         assert len(null_dist) == 100
         assert np.all(null_dist >= 0)
         assert np.all(null_dist <= 1)
+
+        # Cache stores one .npy file per (total, num_pos) pair
+        npy_files = list(cache_dir.glob("*.npy"))
+        assert len(npy_files) == 1
+        assert npy_files[0].name == "n20_k5.npy"
 
 
 def test_null_dist_cached_hit():
@@ -227,6 +230,23 @@ def test_null_dist_cached_hit():
         first = compute.null_dist_cached(**kwargs)
         second = compute.null_dist_cached(**kwargs)
         assert np.array_equal(first, second)
+
+
+def test_null_dist_cached_corrupt():
+    """Test that a corrupted cache file is regenerated, not propagated."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = Path(tmpdir)
+        path = cache_dir / "n20_k5.npy"
+
+        # Write garbage to simulate corruption
+        path.write_bytes(b"not a valid npy file")
+
+        null_dist = compute.null_dist_cached(
+            num_pos=5, total=20, seed=42, null_size=100, cache_dir=cache_dir
+        )
+        assert len(null_dist) == 100
+        assert np.all(null_dist >= 0)
+        assert np.all(null_dist <= 1)
 
 
 def _parallel_worker(args):

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,6 @@ name = "copairs"
 version = "0.5.5.dev0"
 source = { editable = "." }
 dependencies = [
-    { name = "diskcache" },
     { name = "duckdb" },
     { name = "pandas" },
     { name = "statsmodels" },
@@ -609,7 +608,6 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "diskcache" },
     { name = "duckdb", specifier = ">=1.4.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "matplotlib", marker = "extra == 'demo'" },
@@ -705,15 +703,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follows up on #128, which introduced diskcache to fix write corruption from parallel workers. That fix was correct for the write-race problem, but diskcache uses SQLite internally, and SQLite doesn't scale under heavy concurrent access.

## Problem

With 200+ parallel Snakemake jobs (JUMP Cell Painting pipeline), the shared SQLite database becomes a bottleneck. We hit three failure modes, each uncovered after fixing the previous one:

1. `sqlite3.OperationalError: database is locked` during `Cache.__init__` - the constructor runs `PRAGMA` and `INSERT INTO Settings`, which are writes. 200 processes deadlock on init.
2. After adding retry-with-backoff on the constructor: `diskcache.core.Timeout` on `cache.set()` inside multiprocessing workers - steady-state write contention.
3. After wrapping `get`/`set` in retries too: it worked, but fragile. Every cache operation needed error handling for a problem that shouldn't exist.

SQLite is single-writer. WAL mode (which diskcache enables) allows concurrent readers, but every `Cache()` constructor is a writer. No timeout or retry configuration fixes 200 concurrent writer-on-open sessions - it's architectural.

## Fix

Replace diskcache with file-per-key caching using atomic writes:

- **Read**: `np.load(path)` - no lock, no coordination, scales to any number of processes
- **Write**: `tempfile.mkstemp` + `np.save(fd)` + `os.replace(tmp, path)` - `os.replace` is atomic on POSIX (same filesystem), so readers see either the complete old file or the complete new file, never a partial write

This addresses the original corruption from #128 (atomic writes prevent truncation/partial reads) without introducing a shared bottleneck (no SQLite, no locks).

## What changed

- `_cache_read` / `_cache_write`: two small helpers, stdlib only
- `null_dist_cached` and `get_null_dists`: use file helpers instead of `diskcache.Cache`
- Remove `diskcache` from dependencies
- New test: `test_null_dist_cached_corrupt` (verifies graceful recovery from corrupted cache files)

## Test plan

- [x] 68/68 unit tests pass (including parallel stress test from #128)
- [x] Full JUMP pipeline: 124 parallel copairs jobs, cold cache, zero failures
- [x] Previous pipeline runs with diskcache: 222 failures, then 202, then 101 (each fix uncovered the next SQLite contention point)